### PR TITLE
heroku_review_app_config workaround for heroku/heroku-go#60

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ website/node_modules
 
 website/vendor
 
+dist/
+
 # Test exclusions
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/
+


### PR DESCRIPTION
Heroku's API has methods to view and edit the Review App configuration for a Heroku pipeline. The [documentation for that API](https://devcenter.heroku.com/articles/platform-api-reference#review-app-configuration-info) says that the response should contain the field `{"pipeline_id": "some-uuid"}`. The Heroku client for Go is generated from [a JSON Schema](https://devcenter.heroku.com/articles/json-schema-for-platform-api) that also lists this `pipeline_id` field in the response.

Contrary to their docs, the API response does not contain `"pipeline_id"`; it actually contains `"pipeline": { "id": "some-uuid" }`. The Heroku Terraform provider uses the Go client internally, so this affects us when . Here's an example of the response from [the debug logs of a recent Terraform run](https://app.terraform.io/app/readmeio/workspaces/deploybert/runs/run-uSGuWW1anZuK2CtP).

```json
{
    "pipeline": { "id":"32018dcb-bec3-467b-a7cc-0cbcf7450abb" },
    "repo": { "id":402597645 },
    "automatic_review_apps": true,
    "stale_days": 3,
    "destroy_stale_apps": true,
    "wait_for_ci": false,
    "base_name": "deploybert-tf",
    "deploy_target": {"id": "59accabd-516d-4f0e-83e6-6e3757701145", "type": "region"}
}
```

(Side note: You can enable debug logging in Terraform Cloud by setting the environment variable `TF_LOG` to `DEBUG`.)

This has already been [reported as a bug](https://github.com/heroku/heroku-go/issues/60) in the Heroku client for Go.

Because of this bug, the `heroku_review_app_config` resource is broken in the Heroku Terraform provider. Terraform can't properly set the `pipeline_id` field, and this makes it impossible to use the resource to configure Review Apps in a Heroku pipeline. We need to be able to configure Review Apps in pipelines like `readme`.

This workaround should let us configure review app settings even while with that bug.

I'm also going to submit this as an upstream PR to [terraform-provider-heroku](https://github.com/heroku/terraform-provider-heroku), although it would be more appropriate for Heroku to update their JSON Schema and generate a new version of the Go client.